### PR TITLE
Fix up fmod_preload for newer glibc versions

### DIFF
--- a/fmod/fmod_preload.c
+++ b/fmod/fmod_preload.c
@@ -15,11 +15,11 @@ static int FMOD_Studio_EventInstance_SetParameterValue(void *system, const char 
 	return SetParameterByName(system, name, value, 0);
 }
 
-extern void *_dl_sym(void *, const char *, void *);
 void *dlsym(void *handle, const char *name) {
 	static void *(*dlsym_real)(void *, const char *);
 	if (dlsym_real == NULL) {
-		dlsym_real = _dl_sym(RTLD_NEXT, "dlsym", dlsym);
+		dlsym_real = dlvsym(handle, "dlsym", "GLIBC_2.17" /* aarch64 only! */);
+		dlsym_real = dlsym_real(RTLD_NEXT, "dlsym"); // play nice with other hooks
 	}
 	if (name != NULL) {
 		if (strcmp(name, "FMOD_Studio_System_GetLowLevelSystem") == 0) {


### PR DESCRIPTION
The private `_dl_sym` function is missing from newer glibcs. Instead use `dlvsym`, a stable function meant for getting a specific versioned symbol. On ARM64, `GLIBC_2.17` is dlsym's version (other architectures would need different strings).

~~Note that this also uses `dlsym` to get the address of.. `dlsym`, which should play a bit nicer with anyone else who's hooking that. There's a few libraries I've seen around that do it so they can mess with OpenGL or whatever.~~ (Edit: the original code does this too, don't mind me)

Tested working on Ubuntu Jammy for Switch and Fedora 39 Asahi. NOT tested on 18.04, which is still pretty popular on Switch.